### PR TITLE
Fix missing comma in motivational messages list

### DIFF
--- a/lib/static.dart
+++ b/lib/static.dart
@@ -92,8 +92,8 @@ class AppStatic {
     "Keep up the great work! Try a challenge today!",
     "Your next win is waiting. Take on a challenge!",
     "Small steps, big results. Do a challenge!",
-    "Stay motivated! Complete a challenge now!"
-        "You are the sun! But what is the sun if it can't shine?\nDo a challenge!",
+    "Stay motivated! Complete a challenge now!",
+    "You are the sun! But what is the sun if it can't shine?\nDo a challenge!",
     "Are you outside? Then you should do a challenge!",
     "It takes only 5 minutes to do a challenge!\nWhat are you waiting for?",
   ];


### PR DESCRIPTION
## Summary
- separate adjacent strings in `AppStatic.motivationMessages`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895df28819c832c845d95c8ebdae18c