### PR TITLE
feat: refactor streak system from daily to weekly and update progress…

### DIFF
--- a/lib/data/logbook_repository.dart
+++ b/lib/data/logbook_repository.dart
@@ -1,6 +1,8 @@
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
+import '../logic/weekly_streak_logic.dart';
+
 /// All reads and writes to the logbook SQLite table go through this class.
 /// The challenge catalog tables are no longer read here — they live in JSON.
 class LogbookRepository {
@@ -182,42 +184,70 @@ class LogbookRepository {
     ''', [today, today]);
 
     final row = rows.first;
-    final streak = await _currentStreak();
     final totalSeconds = (row['totalSeconds'] as int?) ?? 0;
+    final now = DateTime.now();
+    final xpByWeek = await weeklyXpByWeek(weeks: 52);
+    final weekStreak = WeeklyStreakLogic.countStreak(xpByWeek, now);
+    // pendingWeekStreak: streak from last week — shown in grey when the current
+    // week hasn't reached the threshold yet (grace period motivational cue).
+    // Resets to 0 only when two or more consecutive weeks were missed.
+    final pendingWeekStreak =
+        weekStreak == 0 ? WeeklyStreakLogic.countPendingStreak(xpByWeek, now) : 0;
 
     return {
       'totalXp': (row['totalXp'] as int?) ?? 0,
       'todayXp': (row['todayXp'] as int?) ?? 0,
       'completedAllTime': (row['completedAllTime'] as int?) ?? 0,
       'completedToday': (row['completedToday'] as int?) ?? 0,
-      'streak': streak,
+      'weekStreak': weekStreak,
+      'pendingWeekStreak': pendingWeekStreak,
       'minutesBrave': totalSeconds ~/ 60,
     };
   }
 
-  Future<int> _currentStreak() async {
+  /// XP earned per ISO year-week (e.g. `"2026-W14"`) for the last [weeks] weeks.
+  /// Weeks with no entries are not included in the returned map.
+  Future<Map<String, int>> weeklyXpByWeek({int weeks = 52}) async {
     final db = await _database;
+    final now = DateTime.now();
+    final cutoff = DateTime(now.year, now.month, now.day - weeks * 7)
+        .toIso8601String()
+        .substring(0, 10);
+
     final rows = await db.rawQuery('''
-      SELECT DISTINCT date(timestamp) AS day
+      SELECT timestamp, COALESCE(SUM(earned), 0) AS xp
       FROM logbook
-      WHERE status = 'success'
-      ORDER BY date(timestamp) DESC
-      LIMIT 100
-    ''');
+      WHERE date(timestamp) >= ?
+      GROUP BY strftime('%Y-%W', timestamp)
+    ''', [cutoff]);
 
-    if (rows.isEmpty) return 0;
-
-    final dates = rows
-        .map((r) => DateTime.parse(r['day'] as String))
-        .toList();
-
-    return countStreak(dates, DateTime.now());
+    final result = <String, int>{};
+    for (final r in rows) {
+      final ts = DateTime.parse(r['timestamp'] as String);
+      final key = WeeklyStreakLogic.isoYearWeek(ts);
+      result[key] = (result[key] ?? 0) + (r['xp'] as int);
+    }
+    return result;
   }
 
-  /// Pure streak-counting logic, separated for testability.
+  /// Total XP earned in the current Mon–Sun week.
+  Future<int> currentWeekXp() async {
+    final db = await _database;
+    final now = DateTime.now();
+    final monday = WeeklyStreakLogic.startOfIsoWeek(now);
+    final mondayStr = monday.toIso8601String().substring(0, 10);
+
+    final rows = await db.rawQuery('''
+      SELECT COALESCE(SUM(earned), 0) AS xp
+      FROM logbook
+      WHERE date(timestamp) >= ?
+    ''', [mondayStr]);
+    return (rows.first['xp'] as int?) ?? 0;
+  }
+
+  /// Pure daily-streak-counting logic, kept for the existing test suite.
   /// [successDates] must be distinct dates (time part ignored).
   /// [today] is the reference date (typically DateTime.now()).
-  /// Uses calendar-day arithmetic to avoid DST edge cases.
   static int countStreak(List<DateTime> successDates, DateTime today) {
     if (successDates.isEmpty) return 0;
 
@@ -233,7 +263,6 @@ class LogbookRepository {
         streak++;
       } else {
         if (i == 0) {
-          // It's okay if today is missed, but yesterday must be present.
           continue;
         } else {
           break;

--- a/lib/data/settings_repository.dart
+++ b/lib/data/settings_repository.dart
@@ -33,6 +33,10 @@ class SettingsRepository {
   static const _keyLastCelebratedStreak = 'last_celebrated_streak';
   static const _keyWeeklyGoal = 'weekly_goal';
   static const _keyAllTimeMaxStreak = 'all_time_max_streak';
+  static const _keyBestWeeklyStreak = 'best_weekly_streak';
+  /// ISO year-week (e.g. "2026-W15") of the last week where the weekly XP
+  /// goal was reached and the flame celebration was shown.
+  static const _keyLastGoalWeek = 'last_goal_week';
 
   final SharedPreferences _prefs;
 
@@ -143,6 +147,20 @@ class SettingsRepository {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_keyAllTimeMaxStreak, streak);
   }
+
+  // ─── Best weekly streak ───────────────────────────────────────────────────
+
+  Future<int> loadBestWeeklyStreak() async =>
+      _prefs.getInt(_keyBestWeeklyStreak) ?? 0;
+
+  Future<void> saveBestWeeklyStreak(int streak) async =>
+      _prefs.setInt(_keyBestWeeklyStreak, streak);
+
+  Future<String?> loadLastGoalWeek() async =>
+      _prefs.getString(_keyLastGoalWeek);
+
+  Future<void> saveLastGoalWeek(String isoWeek) async =>
+      _prefs.setString(_keyLastGoalWeek, isoWeek);
 
   // ─── Weekly goal ─────────────────────────────────────────────────────────
 

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -30,7 +30,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m3(done, needed, next) =>
       "${done} / ${needed} Abschlüsse bis Level ${next}";
 
-  static String m4(streak) => "Tag ${streak} — bleib dran.";
+  static String m4(streak) => "Woche ${streak} — bleib dran.";
 
   static String m5(level) => "Level ${level}";
 
@@ -58,9 +58,9 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m15(xp) => "${xp} Aura durch echtes Handeln verdient.";
 
-  static String m16(days) => "Du bist seit ${days} Tagen dabei. Weiter so.";
+  static String m16(days) => "Du bist seit ${days} Wochen dabei. Weiter so.";
 
-  static String m17(days) => "${days}-Tage-Serie!";
+  static String m17(days) => "${days}-Wochen-Serie!";
 
   static String m18(done, goal) => "${done} von ${goal} Challenges diese Woche";
 
@@ -123,12 +123,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "badgeFiveHundredXp": MessageLookupByLibrary.simpleMessage(
       "500-Aura-Legende",
     ),
-    "badgeSevenDayStreak": MessageLookupByLibrary.simpleMessage(
-      "7-Tage-Streak",
+    "badgeSevenWeekStreak": MessageLookupByLibrary.simpleMessage(
+      "7-Wochen-Streak",
     ),
     "badgeTenChallenges": MessageLookupByLibrary.simpleMessage("10 Challenges"),
-    "badgeThreeDayStreak": MessageLookupByLibrary.simpleMessage(
-      "3-Tage-Streak",
+    "badgeThreeWeekStreak": MessageLookupByLibrary.simpleMessage(
+      "3-Wochen-Streak",
     ),
     "badgesLocked": MessageLookupByLibrary.simpleMessage(
       "Weiter so, um mehr freizuschalten!",
@@ -759,22 +759,22 @@ class MessageLookup extends MessageLookupByLibrary {
     "storyXpSmall": m15,
     "streak": MessageLookupByLibrary.simpleMessage("Serie"),
     "streakMilestone100": MessageLookupByLibrary.simpleMessage(
-      "100 Tage. Du hast etwas Außergewöhnliches aufgebaut. Respekt.",
+      "100 Wochen. Du hast etwas Außergewöhnliches aufgebaut. Respekt.",
     ),
     "streakMilestone14": MessageLookupByLibrary.simpleMessage(
-      "Zwei Wochen durchgezogen. Du bist nicht mehr die gleiche Person wie vor 14 Tagen.",
+      "14 Wochen durchgezogen. Du bist nicht mehr die gleiche Person wie vor 14 Wochen.",
     ),
     "streakMilestone3": MessageLookupByLibrary.simpleMessage(
-      "Drei Tage am Stück. Du baust eine Gewohnheit auf.",
+      "3 Wochen am Stück. Du baust eine Gewohnheit auf.",
     ),
     "streakMilestone30": MessageLookupByLibrary.simpleMessage(
-      "30 Tage. Ein ganzer Monat dranbleiben. Das ist selten. Das ist stark.",
+      "30 Wochen. Über ein halbes Jahr. Das ist selten. Das ist stark.",
     ),
     "streakMilestone60": MessageLookupByLibrary.simpleMessage(
-      "60 Tage. Die meisten geben nach einer Woche auf. Du nicht.",
+      "60 Wochen. Die meisten geben nach zwei Monaten auf. Du nicht.",
     ),
     "streakMilestone7": MessageLookupByLibrary.simpleMessage(
-      "Eine ganze Woche! Deine Komfortzone ist gerade gewachsen.",
+      "7 Wochen! Fast zwei Monate drangeblieben. Deine Komfortzone ist gewachsen.",
     ),
     "streakMilestoneGeneric": m16,
     "streakMilestoneTitle": m17,
@@ -816,6 +816,13 @@ class MessageLookup extends MessageLookupByLibrary {
       "Sollen wir dich erinnern?",
     ),
     "wed": MessageLookupByLibrary.simpleMessage("Mi"),
+    "weekStreak": MessageLookupByLibrary.simpleMessage("Wochen-Streak"),
+    "weeklyAuraGoalReached": MessageLookupByLibrary.simpleMessage(
+      "Ziel erreicht! Diese Woche zählt.",
+    ),
+    "weeklyAuraGoalTitle": MessageLookupByLibrary.simpleMessage(
+      "Wöchentliches Aura-Ziel",
+    ),
     "weeklyChallenges": MessageLookupByLibrary.simpleMessage(
       "Wöchentliche Challenges",
     ),
@@ -827,6 +834,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "weeklyXpProgress": MessageLookupByLibrary.simpleMessage(
       "Wöchentliche Aura",
     ),
+    "weeksShort": MessageLookupByLibrary.simpleMessage("Wochen"),
     "wellDone": MessageLookupByLibrary.simpleMessage(
       "Gut gemacht! Mach weiter so!",
     ),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -30,7 +30,7 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m3(done, needed, next) =>
       "${done} / ${needed} completions to Level ${next}";
 
-  static String m4(streak) => "Day ${streak} — keep it going.";
+  static String m4(streak) => "Week ${streak} — keep it going.";
 
   static String m5(level) => "Level ${level}";
 
@@ -58,9 +58,9 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m15(xp) => "${xp} Aura earned through genuine action.";
 
   static String m16(days) =>
-      "You\'ve been showing up for ${days} days. Keep going.";
+      "You\'ve been showing up for ${days} weeks. Keep going.";
 
-  static String m17(days) => "${days}-Day Streak!";
+  static String m17(days) => "${days}-Week Streak!";
 
   static String m18(done, goal) => "${done} of ${goal} challenges this week";
 
@@ -121,9 +121,13 @@ class MessageLookup extends MessageLookupByLibrary {
     "badgeFiveHundredXp": MessageLookupByLibrary.simpleMessage(
       "500 Aura Legend",
     ),
-    "badgeSevenDayStreak": MessageLookupByLibrary.simpleMessage("7-Day Streak"),
+    "badgeSevenWeekStreak": MessageLookupByLibrary.simpleMessage(
+      "7-Week Streak",
+    ),
     "badgeTenChallenges": MessageLookupByLibrary.simpleMessage("10 Challenges"),
-    "badgeThreeDayStreak": MessageLookupByLibrary.simpleMessage("3-Day Streak"),
+    "badgeThreeWeekStreak": MessageLookupByLibrary.simpleMessage(
+      "3-Week Streak",
+    ),
     "badgesLocked": MessageLookupByLibrary.simpleMessage(
       "Keep going to unlock more!",
     ),
@@ -729,22 +733,22 @@ class MessageLookup extends MessageLookupByLibrary {
     "storyXpSmall": m15,
     "streak": MessageLookupByLibrary.simpleMessage("Streak"),
     "streakMilestone100": MessageLookupByLibrary.simpleMessage(
-      "100 days. You\'ve built something extraordinary. Respect.",
+      "100 weeks. You\'ve built something extraordinary. Respect.",
     ),
     "streakMilestone14": MessageLookupByLibrary.simpleMessage(
-      "Two weeks straight. You\'re not the same person you were 14 days ago.",
+      "14 weeks straight. You\'re not the same person you were 14 weeks ago.",
     ),
     "streakMilestone3": MessageLookupByLibrary.simpleMessage(
-      "Three days in a row. You\'re building a habit.",
+      "3 weeks in a row. You\'re building a real habit.",
     ),
     "streakMilestone30": MessageLookupByLibrary.simpleMessage(
-      "30 days. A whole month of showing up. That\'s rare. That\'s powerful.",
+      "30 weeks. Over half a year of showing up. That\'s rare. That\'s powerful.",
     ),
     "streakMilestone60": MessageLookupByLibrary.simpleMessage(
-      "60 days. Most people quit after a week. You didn\'t.",
+      "60 weeks. Most people quit after a month. You didn\'t.",
     ),
     "streakMilestone7": MessageLookupByLibrary.simpleMessage(
-      "A full week! Your comfort zone just got bigger.",
+      "7 weeks! Nearly two months of consistent effort. Your comfort zone has grown.",
     ),
     "streakMilestoneGeneric": m16,
     "streakMilestoneTitle": m17,
@@ -786,6 +790,13 @@ class MessageLookup extends MessageLookupByLibrary {
       "Want us to remind you?",
     ),
     "wed": MessageLookupByLibrary.simpleMessage("W"),
+    "weekStreak": MessageLookupByLibrary.simpleMessage("Week Streak"),
+    "weeklyAuraGoalReached": MessageLookupByLibrary.simpleMessage(
+      "Goal reached! This week counts.",
+    ),
+    "weeklyAuraGoalTitle": MessageLookupByLibrary.simpleMessage(
+      "Weekly Aura Goal",
+    ),
     "weeklyChallenges": MessageLookupByLibrary.simpleMessage(
       "Weekly Challenges",
     ),
@@ -795,6 +806,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "weeklyRecapBody": m19,
     "weeklyRecapTitle": MessageLookupByLibrary.simpleMessage("Weekly Recap"),
     "weeklyXpProgress": MessageLookupByLibrary.simpleMessage("Weekly Aura"),
+    "weeksShort": MessageLookupByLibrary.simpleMessage("weeks"),
     "wellDone": MessageLookupByLibrary.simpleMessage("Well done! Keep it up!"),
     "xp": MessageLookupByLibrary.simpleMessage("XP"),
     "xpEarnedThisWeek": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1844,6 +1844,36 @@ class S {
     return Intl.message('Day Streak', name: 'dayStreak', desc: '', args: []);
   }
 
+  /// `Week Streak`
+  String get weekStreak {
+    return Intl.message('Week Streak', name: 'weekStreak', desc: '', args: []);
+  }
+
+  /// `weeks`
+  String get weeksShort {
+    return Intl.message('weeks', name: 'weeksShort', desc: '', args: []);
+  }
+
+  /// `Weekly Aura Goal`
+  String get weeklyAuraGoalTitle {
+    return Intl.message(
+      'Weekly Aura Goal',
+      name: 'weeklyAuraGoalTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Goal reached! This week counts.`
+  String get weeklyAuraGoalReached {
+    return Intl.message(
+      'Goal reached! This week counts.',
+      name: 'weeklyAuraGoalReached',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Times Tried`
   String get timesTried {
     return Intl.message('Times Tried', name: 'timesTried', desc: '', args: []);
@@ -1929,10 +1959,10 @@ class S {
     );
   }
 
-  /// `Day {streak} — keep it going.`
+  /// `Week {streak} — keep it going.`
   String greetingStreak(int streak) {
     return Intl.message(
-      'Day $streak — keep it going.',
+      'Week $streak — keep it going.',
       name: 'greetingStreak',
       desc: '',
       args: [streak],
@@ -2189,80 +2219,80 @@ class S {
     return Intl.message('Do it later', name: 'doItLater', desc: '', args: []);
   }
 
-  /// `{days}-Day Streak!`
+  /// `{days}-Week Streak!`
   String streakMilestoneTitle(int days) {
     return Intl.message(
-      '$days-Day Streak!',
+      '$days-Week Streak!',
       name: 'streakMilestoneTitle',
       desc: '',
       args: [days],
     );
   }
 
-  /// `Three days in a row. You're building a habit.`
+  /// `3 weeks in a row. You're building a real habit.`
   String get streakMilestone3 {
     return Intl.message(
-      'Three days in a row. You\'re building a habit.',
+      '3 weeks in a row. You\'re building a real habit.',
       name: 'streakMilestone3',
       desc: '',
       args: [],
     );
   }
 
-  /// `A full week! Your comfort zone just got bigger.`
+  /// `7 weeks! Nearly two months of consistent effort. Your comfort zone has grown.`
   String get streakMilestone7 {
     return Intl.message(
-      'A full week! Your comfort zone just got bigger.',
+      '7 weeks! Nearly two months of consistent effort. Your comfort zone has grown.',
       name: 'streakMilestone7',
       desc: '',
       args: [],
     );
   }
 
-  /// `Two weeks straight. You're not the same person you were 14 days ago.`
+  /// `14 weeks straight. You're not the same person you were 14 weeks ago.`
   String get streakMilestone14 {
     return Intl.message(
-      'Two weeks straight. You\'re not the same person you were 14 days ago.',
+      '14 weeks straight. You\'re not the same person you were 14 weeks ago.',
       name: 'streakMilestone14',
       desc: '',
       args: [],
     );
   }
 
-  /// `30 days. A whole month of showing up. That's rare. That's powerful.`
+  /// `30 weeks. Over half a year of showing up. That's rare. That's powerful.`
   String get streakMilestone30 {
     return Intl.message(
-      '30 days. A whole month of showing up. That\'s rare. That\'s powerful.',
+      '30 weeks. Over half a year of showing up. That\'s rare. That\'s powerful.',
       name: 'streakMilestone30',
       desc: '',
       args: [],
     );
   }
 
-  /// `60 days. Most people quit after a week. You didn't.`
+  /// `60 weeks. Most people quit after a month. You didn't.`
   String get streakMilestone60 {
     return Intl.message(
-      '60 days. Most people quit after a week. You didn\'t.',
+      '60 weeks. Most people quit after a month. You didn\'t.',
       name: 'streakMilestone60',
       desc: '',
       args: [],
     );
   }
 
-  /// `100 days. You've built something extraordinary. Respect.`
+  /// `100 weeks. You've built something extraordinary. Respect.`
   String get streakMilestone100 {
     return Intl.message(
-      '100 days. You\'ve built something extraordinary. Respect.',
+      '100 weeks. You\'ve built something extraordinary. Respect.',
       name: 'streakMilestone100',
       desc: '',
       args: [],
     );
   }
 
-  /// `You've been showing up for {days} days. Keep going.`
+  /// `You've been showing up for {days} weeks. Keep going.`
   String streakMilestoneGeneric(int days) {
     return Intl.message(
-      'You\'ve been showing up for $days days. Keep going.',
+      'You\'ve been showing up for $days weeks. Keep going.',
       name: 'streakMilestoneGeneric',
       desc: '',
       args: [days],
@@ -3064,21 +3094,21 @@ class S {
     );
   }
 
-  /// `3-Day Streak`
-  String get badgeThreeDayStreak {
+  /// `3-Week Streak`
+  String get badgeThreeWeekStreak {
     return Intl.message(
-      '3-Day Streak',
-      name: 'badgeThreeDayStreak',
+      '3-Week Streak',
+      name: 'badgeThreeWeekStreak',
       desc: '',
       args: [],
     );
   }
 
-  /// `7-Day Streak`
-  String get badgeSevenDayStreak {
+  /// `7-Week Streak`
+  String get badgeSevenWeekStreak {
     return Intl.message(
-      '7-Day Streak',
-      name: 'badgeSevenDayStreak',
+      '7-Week Streak',
+      name: 'badgeSevenWeekStreak',
       desc: '',
       args: [],
     );

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -276,6 +276,10 @@
   "more": "Mehr",
   "totalXp": "Gesamt-Aura",
   "dayStreak": "Tage-Streak",
+  "weekStreak": "Wochen-Streak",
+  "weeksShort": "Wochen",
+  "weeklyAuraGoalTitle": "Wöchentliches Aura-Ziel",
+  "weeklyAuraGoalReached": "Ziel erreicht! Diese Woche zählt.",
   "timesTried": "Mal versucht",
   "minutesBrave": "Min. mutig",
   "bestStreak": "Bester Streak",
@@ -293,7 +297,7 @@
   "sun": "So",
   "greetingLongTime": "Lange nicht gesehen. Keine Sorge — dein Fortschritt ist noch da.",
   "greetingFresh": "Willkommen zurück. Bereit für einen neuen Start?",
-  "greetingStreak": "Tag {streak} — bleib dran.",
+  "greetingStreak": "Woche {streak} — bleib dran.",
   "@greetingStreak": {
     "placeholders": { "streak": { "type": "int" } }
   },
@@ -328,19 +332,19 @@
   "startNow": "Jetzt starten",
   "doItLater": "Später machen",
 
-  "streakMilestoneTitle": "{days}-Tage-Serie!",
+  "streakMilestoneTitle": "{days}-Wochen-Serie!",
   "@streakMilestoneTitle": {
     "placeholders": {
       "days": {"type": "int"}
     }
   },
-  "streakMilestone3": "Drei Tage am Stück. Du baust eine Gewohnheit auf.",
-  "streakMilestone7": "Eine ganze Woche! Deine Komfortzone ist gerade gewachsen.",
-  "streakMilestone14": "Zwei Wochen durchgezogen. Du bist nicht mehr die gleiche Person wie vor 14 Tagen.",
-  "streakMilestone30": "30 Tage. Ein ganzer Monat dranbleiben. Das ist selten. Das ist stark.",
-  "streakMilestone60": "60 Tage. Die meisten geben nach einer Woche auf. Du nicht.",
-  "streakMilestone100": "100 Tage. Du hast etwas Außergewöhnliches aufgebaut. Respekt.",
-  "streakMilestoneGeneric": "Du bist seit {days} Tagen dabei. Weiter so.",
+  "streakMilestone3": "3 Wochen am Stück. Du baust eine Gewohnheit auf.",
+  "streakMilestone7": "7 Wochen! Fast zwei Monate drangeblieben. Deine Komfortzone ist gewachsen.",
+  "streakMilestone14": "14 Wochen durchgezogen. Du bist nicht mehr die gleiche Person wie vor 14 Wochen.",
+  "streakMilestone30": "30 Wochen. Über ein halbes Jahr. Das ist selten. Das ist stark.",
+  "streakMilestone60": "60 Wochen. Die meisten geben nach zwei Monaten auf. Du nicht.",
+  "streakMilestone100": "100 Wochen. Du hast etwas Außergewöhnliches aufgebaut. Respekt.",
+  "streakMilestoneGeneric": "Du bist seit {days} Wochen dabei. Weiter so.",
   "@streakMilestoneGeneric": {
     "placeholders": {
       "days": {"type": "int"}
@@ -462,8 +466,8 @@
   "badgeFirstStep": "Erster Schritt",
   "badgeTenChallenges": "10 Challenges",
   "badgeFiftyChallenges": "50 Challenges",
-  "badgeThreeDayStreak": "3-Tage-Streak",
-  "badgeSevenDayStreak": "7-Tage-Streak",
+  "badgeThreeWeekStreak": "3-Wochen-Streak",
+  "badgeSevenWeekStreak": "7-Wochen-Streak",
   "badgeCenturyXp": "100-Aura-Club",
   "badgeFiveHundredXp": "500-Aura-Legende",
   "badgeBraveMinutes": "60 Min. mutig",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -276,6 +276,10 @@
   "more": "More",
   "totalXp": "Total Aura",
   "dayStreak": "Day Streak",
+  "weekStreak": "Week Streak",
+  "weeksShort": "weeks",
+  "weeklyAuraGoalTitle": "Weekly Aura Goal",
+  "weeklyAuraGoalReached": "Goal reached! This week counts.",
   "timesTried": "Times Tried",
   "minutesBrave": "Min. Brave",
   "bestStreak": "Best Streak",
@@ -293,7 +297,7 @@
   "sun": "S",
   "greetingLongTime": "Long time. No worries — your progress is still here.",
   "greetingFresh": "Welcome back. Ready to start fresh today?",
-  "greetingStreak": "Day {streak} — keep it going.",
+  "greetingStreak": "Week {streak} — keep it going.",
   "@greetingStreak": {
     "placeholders": { "streak": { "type": "int" } }
   },
@@ -328,19 +332,19 @@
   "startNow": "Start Now",
   "doItLater": "Do it later",
 
-  "streakMilestoneTitle": "{days}-Day Streak!",
+  "streakMilestoneTitle": "{days}-Week Streak!",
   "@streakMilestoneTitle": {
     "placeholders": {
       "days": {"type": "int"}
     }
   },
-  "streakMilestone3": "Three days in a row. You're building a habit.",
-  "streakMilestone7": "A full week! Your comfort zone just got bigger.",
-  "streakMilestone14": "Two weeks straight. You're not the same person you were 14 days ago.",
-  "streakMilestone30": "30 days. A whole month of showing up. That's rare. That's powerful.",
-  "streakMilestone60": "60 days. Most people quit after a week. You didn't.",
-  "streakMilestone100": "100 days. You've built something extraordinary. Respect.",
-  "streakMilestoneGeneric": "You've been showing up for {days} days. Keep going.",
+  "streakMilestone3": "3 weeks in a row. You're building a real habit.",
+  "streakMilestone7": "7 weeks! Nearly two months of consistent effort. Your comfort zone has grown.",
+  "streakMilestone14": "14 weeks straight. You're not the same person you were 14 weeks ago.",
+  "streakMilestone30": "30 weeks. Over half a year of showing up. That's rare. That's powerful.",
+  "streakMilestone60": "60 weeks. Most people quit after a month. You didn't.",
+  "streakMilestone100": "100 weeks. You've built something extraordinary. Respect.",
+  "streakMilestoneGeneric": "You've been showing up for {days} weeks. Keep going.",
   "@streakMilestoneGeneric": {
     "placeholders": {
       "days": {"type": "int"}
@@ -462,8 +466,8 @@
   "badgeFirstStep": "First Step",
   "badgeTenChallenges": "10 Challenges",
   "badgeFiftyChallenges": "50 Challenges",
-  "badgeThreeDayStreak": "3-Day Streak",
-  "badgeSevenDayStreak": "7-Day Streak",
+  "badgeThreeWeekStreak": "3-Week Streak",
+  "badgeSevenWeekStreak": "7-Week Streak",
   "badgeCenturyXp": "100 Aura Club",
   "badgeFiveHundredXp": "500 Aura Legend",
   "badgeBraveMinutes": "60 Min. Brave",

--- a/lib/logic/badges_logic.dart
+++ b/lib/logic/badges_logic.dart
@@ -48,16 +48,16 @@ class BadgesLogic {
       condition: _fiftyChallenges,
     ),
     AppBadge(
-      id: 'three_day_streak',
+      id: 'three_week_streak',
       icon: Icons.local_fire_department_rounded,
       color: Color(0xFFE65100),
-      condition: _threeDayStreak,
+      condition: _threeWeekStreak,
     ),
     AppBadge(
-      id: 'seven_day_streak',
+      id: 'seven_week_streak',
       icon: Icons.whatshot_rounded,
       color: Color(0xFFC62828),
-      condition: _sevenDayStreak,
+      condition: _sevenWeekStreak,
     ),
     AppBadge(
       id: 'century_xp',
@@ -99,10 +99,10 @@ class BadgesLogic {
   static bool _fiftyChallenges(Map<String, int> s, int _) =>
       (s['completedAllTime'] ?? 0) >= 50;
 
-  static bool _threeDayStreak(Map<String, int> s, int best) =>
+  static bool _threeWeekStreak(Map<String, int> s, int best) =>
       best >= 3;
 
-  static bool _sevenDayStreak(Map<String, int> s, int best) =>
+  static bool _sevenWeekStreak(Map<String, int> s, int best) =>
       best >= 7;
 
   static bool _centuryXp(Map<String, int> s, int _) =>

--- a/lib/logic/comfort_zone_logic.dart
+++ b/lib/logic/comfort_zone_logic.dart
@@ -6,14 +6,37 @@ import '../challenge.dart';
 /// Ten-level comfort zone progression system.
 ///
 /// Levels progress from micro-interactions (1) to elite social mastery (10).
-/// Each level unlocks after [completionsToUnlock] successful completions
-/// at the current level. Levels are stored as integers 1–[maxLevel].
+/// Each level unlocks after [completionsNeeded] successful completions.
+/// The threshold grows with each level so early progress feels fast and
+/// later mastery requires real commitment.
+/// Levels are stored as integers 1–[maxLevel].
 ///
 /// Challenge difficulty levels are assigned explicitly in the catalog JSON
 /// (the `level` field), not computed at runtime.
 class ComfortZoneLogic {
-  static const completionsToUnlock = 3;
   static const maxLevel = 10;
+
+  /// Completions required to advance from [level] to [level + 1].
+  /// Index matches the current level (index 0 unused).
+  static const List<int> _completionsPerLevel = [
+    0,   // index 0: unused
+    3,   // level 1 → 2
+    5,   // level 2 → 3
+    8,   // level 3 → 4
+    12,  // level 4 → 5
+    16,  // level 5 → 6
+    20,  // level 6 → 7
+    25,  // level 7 → 8
+    30,  // level 8 → 9
+    35,  // level 9 → 10
+  ];
+
+  /// Returns the number of successful completions needed to advance from
+  /// [level] to the next level. Clamped to valid range.
+  static int completionsNeeded(int level) {
+    final idx = level.clamp(1, _completionsPerLevel.length - 1);
+    return _completionsPerLevel[idx];
+  }
 
   static const levelNames = [
     '',                       // index 0 unused
@@ -107,7 +130,7 @@ class ComfortZoneLogic {
     final newCount = (prefs.getInt(key) ?? 0) + 1;
     await prefs.setInt(key, newCount);
 
-    if (newCount >= completionsToUnlock) {
+    if (newCount >= completionsNeeded(currentLevel)) {
       return currentLevel + 1;
     }
     return null;

--- a/lib/logic/weekly_streak_logic.dart
+++ b/lib/logic/weekly_streak_logic.dart
@@ -1,0 +1,111 @@
+/// Pure, side-effect-free logic for the weekly streak system.
+///
+/// A week is "active" when the user earned ≥ [kWeeklyXpThreshold] Aura Points
+/// in that Mon–Sun period. The streak counts consecutive *completed* weeks
+/// (the current in-progress week never counts toward the streak yet).
+library;
+
+/// Minimum XP to earn in a Mon–Sun week for it to count as an active week.
+const int kWeeklyXpThreshold = 300;
+
+class WeeklyStreakLogic {
+  WeeklyStreakLogic._();
+
+  /// Returns an ISO year-week string for [date], e.g. `"2026-W14"`.
+  ///
+  /// Uses ISO 8601 week numbering: weeks start on Monday, week 01 is the week
+  /// containing the first Thursday of the year.
+  static String isoYearWeek(DateTime date) {
+    // Shift to Thursday of the same ISO week to get the correct ISO year.
+    final thursday = date.add(Duration(days: 4 - date.weekday));
+    final jan4 = DateTime(thursday.year, 1, 4);
+    final startOfWeek1 =
+        jan4.subtract(Duration(days: jan4.weekday - 1));
+    final weekNumber =
+        ((thursday.difference(startOfWeek1).inDays) ~/ 7) + 1;
+    return '${thursday.year}-W${weekNumber.toString().padLeft(2, '0')}';
+  }
+
+  /// Returns the ISO year-week of the Monday that starts the week containing [date].
+  static DateTime startOfIsoWeek(DateTime date) {
+    return DateTime(date.year, date.month, date.day - (date.weekday - 1));
+  }
+
+  /// Counts consecutive weeks (including the current in-progress week) where
+  /// XP ≥ [threshold], going backwards from today's week.
+  ///
+  /// The current week counts as soon as its XP reaches the threshold — the
+  /// streak increments immediately, not at the next week boundary.
+  /// On Monday of a new week, if the user has not yet reached the threshold,
+  /// the current week has 0 qualifying XP and the streak shows 0 (grey).
+  ///
+  /// [xpByWeek] maps ISO year-week strings (e.g. `"2026-W14"`) to total XP
+  /// earned that week. Missing weeks are treated as 0 XP.
+  static int countStreak(
+    Map<String, int> xpByWeek,
+    DateTime today, {
+    int threshold = kWeeklyXpThreshold,
+  }) {
+    final currentWeekMonday = startOfIsoWeek(today);
+    int streak = 0;
+
+    for (int weeksBack = 0; weeksBack <= 200; weeksBack++) {
+      // Use explicit date arithmetic (year/month/day) to avoid DST-shift bugs
+      // that occur when subtracting Duration across a DST boundary.
+      final weekStart = DateTime(
+        currentWeekMonday.year,
+        currentWeekMonday.month,
+        currentWeekMonday.day - weeksBack * 7,
+      );
+      final weekKey = isoYearWeek(weekStart);
+      final xp = xpByWeek[weekKey] ?? 0;
+      if (xp >= threshold) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+
+    return streak;
+  }
+
+  /// Counts consecutive qualifying weeks starting from *last* week (not the
+  /// current in-progress week). Used to compute the "pending" streak shown
+  /// in grey when the user hasn't yet activated the current week.
+  ///
+  /// Returns 0 if last week did not qualify (streak truly broken after 2+
+  /// missed weeks).
+  static int countPendingStreak(
+    Map<String, int> xpByWeek,
+    DateTime today, {
+    int threshold = kWeeklyXpThreshold,
+  }) {
+    final currentWeekMonday = startOfIsoWeek(today);
+    int streak = 0;
+
+    for (int weeksBack = 1; weeksBack <= 200; weeksBack++) {
+      final weekStart = DateTime(
+        currentWeekMonday.year,
+        currentWeekMonday.month,
+        currentWeekMonday.day - weeksBack * 7,
+      );
+      final weekKey = isoYearWeek(weekStart);
+      final xp = xpByWeek[weekKey] ?? 0;
+      if (xp >= threshold) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+
+    return streak;
+  }
+
+  /// Returns whether the current week is on track (XP ≥ threshold already
+  /// earned this week).
+  static bool isCurrentWeekComplete(
+    int currentWeekXp, {
+    int threshold = kWeeklyXpThreshold,
+  }) =>
+      currentWeekXp >= threshold;
+}

--- a/lib/providers/statistics_providers.dart
+++ b/lib/providers/statistics_providers.dart
@@ -59,7 +59,12 @@ class _WeeklyGoalNotifier extends StateNotifier<int> {
 }
 final personalBestStreakProvider = FutureProvider<int>((ref) {
   ref.watch(statisticsRefreshProvider);
-  return SettingsRepository.instance.loadAllTimeMaxStreak();
+  return SettingsRepository.instance.loadBestWeeklyStreak();
+});
+
+final currentWeekXpProvider = FutureProvider<int>((ref) {
+  ref.watch(statisticsRefreshProvider);
+  return LogbookRepository.instance.currentWeekXp();
 });
 
 final moodHistoryProvider =

--- a/lib/routes/challenge_done_screen.dart
+++ b/lib/routes/challenge_done_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../challenge.dart';
 import '../data/logbook_repository.dart';
 import '../data/settings_repository.dart';
+import '../logic/weekly_streak_logic.dart';
 import '../generated/l10n.dart';
 import '../providers/settings_providers.dart';
 import '../providers/statistics_providers.dart' show refreshStatistics;
@@ -369,22 +370,35 @@ class _ChallengeDoneScreenState extends ConsumerState<ChallengeDoneScreen> {
     }
 
     if (!_isAborted && context.mounted) {
-      final stats = await LogbookRepository.instance.overviewStats();
-      final streak = stats['streak'] ?? 0;
+      // ── Weekly XP goal celebration ────────────────────────────────────
+      // Fire the flame animation as soon as the user reaches the weekly
+      // XP threshold — not at the week boundary. Uses an ISO year-week key
+      // so the celebration fires at most once per week.
+      final currentWeekXp =
+          await LogbookRepository.instance.currentWeekXp();
+      if (currentWeekXp >= kWeeklyXpThreshold) {
+        final currentWeek =
+            WeeklyStreakLogic.isoYearWeek(DateTime.now());
+        final lastGoalWeek =
+            await SettingsRepository.instance.loadLastGoalWeek();
 
-      final prevBest = await SettingsRepository.instance.loadAllTimeMaxStreak();
-      if (streak > prevBest) {
-        await SettingsRepository.instance.saveAllTimeMaxStreak(streak);
-      }
+        if (lastGoalWeek != currentWeek) {
+          await SettingsRepository.instance.saveLastGoalWeek(currentWeek);
 
-      final lastCelebrated =
-          await SettingsRepository.instance.loadLastCelebratedStreak();
+          // weekStreak already includes the current week (since threshold is met).
+          final stats = await LogbookRepository.instance.overviewStats();
+          final weekStreak = stats['weekStreak'] ?? 0;
 
-      if (streak > lastCelebrated) {
-        await SettingsRepository.instance.saveLastCelebratedStreak(streak);
-        final isMilestone = AppStatic.streakMilestones.contains(streak);
-        if (context.mounted) {
-          await context.goStreakCelebration(streak, isMilestone);
+          final prevBest =
+              await SettingsRepository.instance.loadBestWeeklyStreak();
+          if (weekStreak > prevBest) {
+            await SettingsRepository.instance.saveBestWeeklyStreak(weekStreak);
+          }
+
+          final isMilestone = AppStatic.streakMilestones.contains(weekStreak);
+          if (context.mounted) {
+            await context.goStreakCelebration(weekStreak, isMilestone);
+          }
         }
       }
     }

--- a/lib/routes/challenges/challenges_header.dart
+++ b/lib/routes/challenges/challenges_header.dart
@@ -12,10 +12,17 @@ class ChallengesHeader extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final stats = ref.watch(overviewStatsProvider);
     final totalXp = stats.whenOrNull(data: (s) => s['totalXp']) ?? 0;
-    final streak = stats.whenOrNull(data: (s) => s['streak']) ?? 0;
-    final completedToday = stats.whenOrNull(data: (s) => s['completedToday']) ?? 0;
-    final isStreakActiveToday = completedToday > 0;
+    final weekStreak = stats.whenOrNull(data: (s) => s['weekStreak']) ?? 0;
+    final pendingWeekStreak =
+        stats.whenOrNull(data: (s) => s['pendingWeekStreak']) ?? 0;
+    // Active (orange): current week already hit the threshold.
+    // Pending (grey with count): last week qualified but current week not yet —
+    //   one-week grace period, shows previous streak as motivational cue.
+    // Reset (grey 0): two or more consecutive weeks missed.
+    final isStreakActive = weekStreak > 0;
+    final displayStreak = weekStreak > 0 ? weekStreak : pendingWeekStreak;
     final cs = Theme.of(context).colorScheme;
+    final l = S.of(context);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(
@@ -24,18 +31,18 @@ class ChallengesHeader extends ConsumerWidget {
         children: [
           Expanded(
             child: Text(
-              S.of(context).navChallenge,
+              l.navChallenge,
               style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
             ),
           ),
-          // Streak badge
+          // Weekly streak badge
           Container(
             padding: const EdgeInsets.symmetric(
                 horizontal: AppSpacing.md, vertical: AppSpacing.sm),
             decoration: BoxDecoration(
-              color: streak > 0 && isStreakActiveToday
+              color: isStreakActive
                   ? cs.tertiary.withValues(alpha: 0.12)
                   : cs.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(AppSpacing.chipRadius),
@@ -46,16 +53,14 @@ class ChallengesHeader extends ConsumerWidget {
                 Icon(
                   Icons.local_fire_department_rounded,
                   size: 18,
-                  color: streak > 0 && isStreakActiveToday ? cs.tertiary : cs.outline,
+                  color: isStreakActive ? cs.tertiary : cs.outline,
                 ),
                 const SizedBox(width: AppSpacing.xs),
                 Text(
-                  '$streak',
+                  '$displayStreak ${l.weeksShort}',
                   style: Theme.of(context).textTheme.labelLarge?.copyWith(
                         fontWeight: FontWeight.bold,
-                        color: streak > 0 && isStreakActiveToday
-                            ? cs.tertiary
-                            : cs.outline,
+                        color: isStreakActive ? cs.tertiary : cs.outline,
                       ),
                 ),
               ],

--- a/lib/routes/settings_screen.dart
+++ b/lib/routes/settings_screen.dart
@@ -392,9 +392,10 @@ class _ComfortZoneLevelCard extends ConsumerWidget {
 
     final isMaxLevel = level >= ComfortZoneLogic.maxLevel;
     final levelName = ComfortZoneLogic.levelNames[level];
+    final needed = ComfortZoneLogic.completionsNeeded(level);
     final progress = isMaxLevel
         ? 1.0
-        : (completions / ComfortZoneLogic.completionsToUnlock).clamp(0.0, 1.0);
+        : (completions / needed).clamp(0.0, 1.0);
 
     final gradient = ComfortZoneLogic.levelGradient(level);
     final levelIcon = ComfortZoneLogic.levelIcons[level.clamp(1, ComfortZoneLogic.levelIcons.length - 1)];
@@ -454,7 +455,7 @@ class _ComfortZoneLevelCard extends ConsumerWidget {
                   Text(
                     S.of(context).completionsToLevel(
                         completions,
-                        ComfortZoneLogic.completionsToUnlock,
+                        needed,
                         level + 1),
                     style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant),
                   ),

--- a/lib/routes/statistics/badges_section.dart
+++ b/lib/routes/statistics/badges_section.dart
@@ -13,8 +13,8 @@ class BadgesSection extends ConsumerWidget {
         'first_step' => l.badgeFirstStep,
         'ten_challenges' => l.badgeTenChallenges,
         'fifty_challenges' => l.badgeFiftyChallenges,
-        'three_day_streak' => l.badgeThreeDayStreak,
-        'seven_day_streak' => l.badgeSevenDayStreak,
+        'three_week_streak' => l.badgeThreeWeekStreak,
+        'seven_week_streak' => l.badgeSevenWeekStreak,
         'century_xp' => l.badgeCenturyXp,
         'five_hundred_xp' => l.badgeFiveHundredXp,
         'brave_minutes' => l.badgeBraveMinutes,
@@ -32,7 +32,7 @@ class BadgesSection extends ConsumerWidget {
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
       data: (stats) {
-        final earned = BadgesLogic.computeEarned(stats, stats['streak'] ?? 0);
+        final earned = BadgesLogic.computeEarned(stats, stats['weekStreak'] ?? 0);
         return Card(
           child: Padding(
             padding: const EdgeInsets.all(AppSpacing.md),

--- a/lib/routes/statistics/overview_grid.dart
+++ b/lib/routes/statistics/overview_grid.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../generated/l10n.dart';
+import '../../logic/weekly_streak_logic.dart';
 import '../../providers/statistics_providers.dart';
 import '../../theme/app_spacing.dart';
 
@@ -12,6 +13,7 @@ class StatsOverviewGrid extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final async = ref.watch(overviewStatsProvider);
     final bestStreakAsync = ref.watch(personalBestStreakProvider);
+    final currentWeekXpAsync = ref.watch(currentWeekXpProvider);
 
     return async.when(
       loading: () => const StatsShimmer(),
@@ -20,53 +22,142 @@ class StatsOverviewGrid extends ConsumerWidget {
         final l = S.of(context);
         final cs = Theme.of(context).colorScheme;
         final bestStreak = bestStreakAsync.valueOrNull ?? 0;
-        return GridView.count(
-          crossAxisCount: 2,
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          mainAxisSpacing: AppSpacing.sm,
-          crossAxisSpacing: AppSpacing.sm,
-          childAspectRatio: 1.3,
+        final currentWeekXp = currentWeekXpAsync.valueOrNull ?? 0;
+        final weekProgress =
+            (currentWeekXp / kWeeklyXpThreshold).clamp(0.0, 1.0);
+        final weekStreak = stats['weekStreak'] ?? 0;
+        final pendingWeekStreak = stats['pendingWeekStreak'] ?? 0;
+        final displayStreak = weekStreak > 0 ? weekStreak : pendingWeekStreak;
+        final isStreakActive = weekStreak > 0;
+        return Column(
           children: [
-            StatCard(
-              icon: Icons.emoji_events,
-              value: '${stats['totalXp']}',
-              label: l.totalXp,
-              color: cs.primary,
+            // ── Weekly Aura progress card ────────────────────────────────
+            _WeeklyAuraCard(
+              currentXp: currentWeekXp,
+              progress: weekProgress,
             ),
-            StatCard(
-              icon: Icons.local_fire_department,
-              value: '${stats['streak']}',
-              label: l.dayStreak,
-              color: const Color(0xFFFF6D00),
-            ),
-            StatCard(
-              icon: Icons.directions_run_rounded,
-              value: '${stats['completedAllTime']}',
-              label: l.timesTried,
-              color: cs.secondary,
-            ),
-            StatCard(
-              icon: Icons.timer_outlined,
-              value: '${stats['minutesBrave'] ?? 0}',
-              label: l.minutesBrave,
-              color: Colors.blueAccent,
-            ),
-            StatCard(
-              icon: Icons.military_tech_rounded,
-              value: '$bestStreak',
-              label: l.bestStreak,
-              color: const Color(0xFFFFB300),
-            ),
-            StatCard(
-              icon: Icons.today_rounded,
-              value: '${stats['completedToday'] ?? 0}',
-              label: l.doneToday,
-              color: cs.tertiary,
+            const SizedBox(height: AppSpacing.sm),
+            // ── Stats grid ───────────────────────────────────────────────
+            GridView.count(
+              crossAxisCount: 2,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              mainAxisSpacing: AppSpacing.sm,
+              crossAxisSpacing: AppSpacing.sm,
+              childAspectRatio: 1.3,
+              children: [
+                StatCard(
+                  icon: Icons.emoji_events,
+                  value: '${stats['totalXp']}',
+                  label: l.totalXp,
+                  color: cs.primary,
+                ),
+                StatCard(
+                  icon: Icons.local_fire_department,
+                  value: '$displayStreak',
+                  label: l.weekStreak,
+                  color: isStreakActive
+                      ? const Color(0xFFFF6D00)
+                      : null, // null → grey (pending or reset)
+                ),
+                StatCard(
+                  icon: Icons.directions_run_rounded,
+                  value: '${stats['completedAllTime']}',
+                  label: l.timesTried,
+                  color: cs.secondary,
+                ),
+                StatCard(
+                  icon: Icons.timer_outlined,
+                  value: '${stats['minutesBrave'] ?? 0}',
+                  label: l.minutesBrave,
+                  color: Colors.blueAccent,
+                ),
+                StatCard(
+                  icon: Icons.military_tech_rounded,
+                  value: '$bestStreak',
+                  label: l.bestStreak,
+                  color: const Color(0xFFFFB300),
+                ),
+                StatCard(
+                  icon: Icons.today_rounded,
+                  value: '${stats['completedToday'] ?? 0}',
+                  label: l.doneToday,
+                  color: cs.tertiary,
+                ),
+              ],
             ),
           ],
         );
       },
+    );
+  }
+}
+
+class _WeeklyAuraCard extends StatelessWidget {
+  final int currentXp;
+  final double progress; // 0.0–1.0
+
+  const _WeeklyAuraCard({required this.currentXp, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final l = S.of(context);
+    final isComplete = progress >= 1.0;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  isComplete
+                      ? Icons.check_circle_rounded
+                      : Icons.local_fire_department_outlined,
+                  size: 18,
+                  color: isComplete ? Colors.green : cs.primary,
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Text(
+                  l.weeklyAuraGoalTitle,
+                  style: tt.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                Text(
+                  '$currentXp / $kWeeklyXpThreshold ${l.auraPoints}',
+                  style: tt.labelSmall
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: progress,
+                minHeight: 8,
+                backgroundColor: cs.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  isComplete ? Colors.green : cs.primary,
+                ),
+              ),
+            ),
+            if (isComplete) ...[
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                l.weeklyAuraGoalReached,
+                style: tt.labelSmall
+                    ?.copyWith(color: Colors.green),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/comfort_zone_logic_test.dart
+++ b/test/comfort_zone_logic_test.dart
@@ -63,12 +63,42 @@ void main() {
       expect(ComfortZoneLogic.levelNames.length, ComfortZoneLogic.maxLevel + 1);
     });
 
-    test('completionsToUnlock is positive', () {
-      expect(ComfortZoneLogic.completionsToUnlock, greaterThan(0));
-    });
-
     test('maxLevel is 10', () {
       expect(ComfortZoneLogic.maxLevel, 10);
+    });
+  });
+
+  group('ComfortZoneLogic.completionsNeeded', () {
+    test('level 1 requires 3 completions', () {
+      expect(ComfortZoneLogic.completionsNeeded(1), 3);
+    });
+
+    test('completions needed increases with each level', () {
+      // Only levels 1..maxLevel-1 have a "next level" to advance to.
+      for (int level = 1; level < ComfortZoneLogic.maxLevel - 1; level++) {
+        expect(
+          ComfortZoneLogic.completionsNeeded(level + 1),
+          greaterThan(ComfortZoneLogic.completionsNeeded(level)),
+          reason: 'Level ${level + 1} should need more than level $level',
+        );
+      }
+    });
+
+    test('all levels have positive completions needed', () {
+      for (int level = 1; level < ComfortZoneLogic.maxLevel; level++) {
+        expect(ComfortZoneLogic.completionsNeeded(level), greaterThan(0));
+      }
+    });
+
+    test('level 9 requires 35 completions', () {
+      expect(ComfortZoneLogic.completionsNeeded(9), 35);
+    });
+
+    test('clamped to valid range for out-of-bounds input', () {
+      expect(ComfortZoneLogic.completionsNeeded(0),
+          ComfortZoneLogic.completionsNeeded(1));
+      expect(ComfortZoneLogic.completionsNeeded(99),
+          ComfortZoneLogic.completionsNeeded(9));
     });
   });
 }

--- a/test/weekly_streak_logic_test.dart
+++ b/test/weekly_streak_logic_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:syntra/logic/weekly_streak_logic.dart';
+
+void main() {
+  // Reference Monday 2026-04-06 (week 15)
+  final monday = DateTime(2026, 4, 6);
+  // Wednesday mid-week
+  final wednesday = DateTime(2026, 4, 8);
+  // Sunday end-of-week
+  final sunday = DateTime(2026, 4, 5); // week 14
+
+  // ── isoYearWeek ────────────────────────────────────────────────────────────
+
+  group('WeeklyStreakLogic.isoYearWeek', () {
+    test('Monday 2026-04-06 is 2026-W15', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2026, 4, 6)), '2026-W15');
+    });
+
+    test('Sunday 2026-04-05 is 2026-W14', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2026, 4, 5)), '2026-W14');
+    });
+
+    test('Wednesday 2026-04-08 is same week as its Monday', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2026, 4, 8)),
+          WeeklyStreakLogic.isoYearWeek(DateTime(2026, 4, 6)));
+    });
+
+    test('first day of year 2026-01-01 (Thursday) is 2026-W01', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2026, 1, 1)), '2026-W01');
+    });
+
+    test('2025-12-29 (Monday) belongs to 2026-W01', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2025, 12, 29)), '2026-W01');
+    });
+
+    test('2025-12-28 (Sunday) belongs to 2025-W52', () {
+      expect(WeeklyStreakLogic.isoYearWeek(DateTime(2025, 12, 28)), '2025-W52');
+    });
+  });
+
+  // ── startOfIsoWeek ─────────────────────────────────────────────────────────
+
+  group('WeeklyStreakLogic.startOfIsoWeek', () {
+    test('Monday returns itself', () {
+      expect(WeeklyStreakLogic.startOfIsoWeek(monday), monday);
+    });
+
+    test('Wednesday returns previous Monday', () {
+      expect(WeeklyStreakLogic.startOfIsoWeek(wednesday), monday);
+    });
+
+    test('Sunday 2026-04-05 returns Monday 2026-03-30', () {
+      expect(WeeklyStreakLogic.startOfIsoWeek(sunday), DateTime(2026, 3, 30));
+    });
+  });
+
+  // ── countStreak ────────────────────────────────────────────────────────────
+
+  group('WeeklyStreakLogic.countStreak', () {
+    // today = Monday 2026-04-06 (W15). Last completed week = W14.
+
+    test('returns 0 for empty xpByWeek', () {
+      expect(WeeklyStreakLogic.countStreak({}, monday), 0);
+    });
+
+    test('returns 0 when current week has 0 XP (new week, not yet farmed)', () {
+      // Current week W15 has 0 XP → streak is 0 even if previous weeks qualified
+      expect(WeeklyStreakLogic.countStreak({'2026-W14': 400}, monday), 0);
+    });
+
+    test('returns 0 when current week XP is below threshold', () {
+      expect(WeeklyStreakLogic.countStreak({'2026-W15': 299}, monday), 0);
+    });
+
+    test('returns 1 when current week just hit threshold', () {
+      expect(WeeklyStreakLogic.countStreak({'2026-W15': 300}, monday), 1);
+    });
+
+    test('returns 1 when current week hit threshold but previous week did not', () {
+      final xp = {'2026-W15': 400, '2026-W14': 100};
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 1);
+    });
+
+    test('returns 2 when current and previous week both qualify', () {
+      final xp = {'2026-W15': 400, '2026-W14': 350};
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 2);
+    });
+
+    test('returns 3 for three consecutive qualifying weeks including current', () {
+      final xp = {
+        '2026-W15': 500,
+        '2026-W14': 300,
+        '2026-W13': 400,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 3);
+    });
+
+    test('stops at first gap — past qualifying week does not help', () {
+      final xp = {
+        '2026-W15': 500,
+        '2026-W14': 0,   // gap
+        '2026-W13': 400,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 1);
+    });
+
+    test('current week XP counts immediately once threshold is reached', () {
+      final xp = {
+        '2026-W15': 999, // current week — must count
+        '2026-W14': 300,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 2);
+    });
+
+    test('mid-week: current week counts if threshold already reached', () {
+      // today = Wednesday W15
+      final xp = {
+        '2026-W15': 400,
+        '2026-W14': 300,
+        '2026-W13': 300,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, wednesday), 3);
+    });
+
+    test('mid-week: streak is 0 if current week not yet qualified', () {
+      // today = Wednesday W15, current week has only 100 XP
+      final xp = {
+        '2026-W15': 100,
+        '2026-W14': 300,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, wednesday), 0);
+    });
+
+    test('missing previous weeks treated as 0 XP (breaks streak)', () {
+      // Only current week present → streak is 1
+      final xp = {'2026-W15': 400};
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 1);
+    });
+
+    test('respects custom threshold', () {
+      final xp = {'2026-W15': 150};
+      expect(WeeklyStreakLogic.countStreak(xp, monday, threshold: 100), 1);
+      expect(WeeklyStreakLogic.countStreak(xp, monday, threshold: 200), 0);
+    });
+
+    test('handles streak from Sunday mid-week (W14)', () {
+      // today = Sunday 2026-04-05 (W14). Current week W14 qualifies.
+      final xp = {'2026-W14': 350, '2026-W13': 300};
+      expect(WeeklyStreakLogic.countStreak(xp, sunday), 2);
+    });
+
+    test('on Monday of new week with 0 XP, previous streak is not shown', () {
+      // today = Monday W15, hasn't farmed yet → streak = 0
+      final xp = {
+        '2026-W15': 0,
+        '2026-W14': 400,
+        '2026-W13': 400,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 0);
+    });
+
+    test('large streak counts correctly including current week', () {
+      // W15 (current) down to W06 = 10 consecutive qualifying weeks
+      final xp = {
+        for (int w = 0; w <= 9; w++) '2026-W${(15 - w).toString().padLeft(2, '0')}': 400,
+      };
+      expect(WeeklyStreakLogic.countStreak(xp, monday), 10);
+    });
+  });
+
+  // ── countPendingStreak ────────────────────────────────────────────────────
+
+  group('WeeklyStreakLogic.countPendingStreak', () {
+    test('returns 0 when last week had 0 XP (streak truly broken)', () {
+      expect(WeeklyStreakLogic.countPendingStreak({}, monday), 0);
+    });
+
+    test('returns 0 when last week was below threshold', () {
+      expect(
+        WeeklyStreakLogic.countPendingStreak({'2026-W14': 299}, monday),
+        0,
+      );
+    });
+
+    test('returns 1 when only last week qualified', () {
+      expect(
+        WeeklyStreakLogic.countPendingStreak({'2026-W14': 300}, monday),
+        1,
+      );
+    });
+
+    test('returns 3 when last three weeks qualified', () {
+      final xp = {
+        '2026-W14': 400,
+        '2026-W13': 350,
+        '2026-W12': 300,
+      };
+      expect(WeeklyStreakLogic.countPendingStreak(xp, monday), 3);
+    });
+
+    test('ignores current week entirely', () {
+      // Current week W15 has lots of XP but should not be counted
+      final xp = {'2026-W15': 999, '2026-W14': 400};
+      expect(WeeklyStreakLogic.countPendingStreak(xp, monday), 1);
+    });
+
+    test('returns 0 when last week missed even if week before qualified', () {
+      final xp = {'2026-W14': 0, '2026-W13': 500};
+      expect(WeeklyStreakLogic.countPendingStreak(xp, monday), 0);
+    });
+
+    test('grace period: one missed week shows previous streak, two resets to 0', () {
+      final xp = {'2026-W14': 400, '2026-W13': 350, '2026-W12': 300};
+      // Current week (W15) not yet active → pending = 3
+      expect(WeeklyStreakLogic.countPendingStreak(xp, monday), 3);
+
+      // Simulate next Monday (W16): last week W15 had 0 XP → pending = 0
+      final nextMonday = DateTime(2026, 4, 13);
+      expect(WeeklyStreakLogic.countPendingStreak(xp, nextMonday), 0);
+    });
+  });
+
+  // ── isCurrentWeekComplete ──────────────────────────────────────────────────
+
+  group('WeeklyStreakLogic.isCurrentWeekComplete', () {
+    test('returns true when XP equals threshold', () {
+      expect(WeeklyStreakLogic.isCurrentWeekComplete(300), isTrue);
+    });
+
+    test('returns true when XP exceeds threshold', () {
+      expect(WeeklyStreakLogic.isCurrentWeekComplete(450), isTrue);
+    });
+
+    test('returns false when XP is below threshold', () {
+      expect(WeeklyStreakLogic.isCurrentWeekComplete(299), isFalse);
+    });
+
+    test('returns false for zero XP', () {
+      expect(WeeklyStreakLogic.isCurrentWeekComplete(0), isFalse);
+    });
+
+    test('respects custom threshold', () {
+      expect(
+          WeeklyStreakLogic.isCurrentWeekComplete(150, threshold: 100), isTrue);
+      expect(
+          WeeklyStreakLogic.isCurrentWeekComplete(50, threshold: 100), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
…ion logic

- **Weekly Streak System:**
    - Replaced the daily streak system with a weekly streak based on a Mon–Sun period and an XP threshold (300 Aura Points).
    - Implemented `WeeklyStreakLogic` to handle ISO 8601 week calculations and streak counting with a one-week grace period.
    - Updated `LogbookRepository` to support weekly XP queries and `SettingsRepository` to persist weekly streak milestones.
    - Updated UI components (`OverviewGrid`, `ChallengesHeader`, `ChallengeDoneScreen`) to display and celebrate weekly milestones.
- **Comfort Zone Progression:**
    - Refactored `ComfortZoneLogic` to use a dynamic scaling threshold for level advancement instead of a fixed completion count.
    - Incremental thresholds now range from 3 completions (Level 1) up to 35 completions (Level 9).
- **Badges and Localization:**
    - Updated streak-based badges from "days" to "weeks".
    - Added and updated localization strings in English and German for all weekly streak terminology and milestone messages.
- **Testing:**
    - Added comprehensive unit tests for `WeeklyStreakLogic`.
    - Updated `ComfortZoneLogic` tests to reflect new completion threshold requirements.