### PR TITLE
chore: code quality — extract providers, constants, and widgets

### DIFF
--- a/lib/providers/daily_providers.dart
+++ b/lib/providers/daily_providers.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../logic/daily_missions_logic.dart';
+import 'settings_providers.dart' show activeLocaleProvider;
+import 'shared_preferences_provider.dart';
+
+final dailyMissionsProvider =
+    AsyncNotifierProvider<DailyMissionsNotifier, List<DailyMission>>(
+        DailyMissionsNotifier.new);
+
+class DailyMissionsNotifier extends AsyncNotifier<List<DailyMission>> {
+  @override
+  Future<List<DailyMission>> build() async {
+    final lang = ref.watch(activeLocaleProvider);
+    final prefs = ref.read(sharedPreferencesProvider);
+    return DailyMissionsLogic().getTodayMissions(lang, prefs);
+  }
+
+  Future<void> markCompleted(MissionTier tier) async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    await DailyMissionsLogic().markCompleted(tier, prefs);
+    final current = state.value;
+    if (current == null) return;
+    state = AsyncData(
+      current
+          .map((m) => m.tier == tier ? m.copyWith(completed: true) : m)
+          .toList(),
+    );
+  }
+}

--- a/lib/routes/active_challenge_screen.dart
+++ b/lib/routes/active_challenge_screen.dart
@@ -18,6 +18,11 @@ import 'package:syntra/widgets/syntra_button.dart';
 import 'package:syntra/widgets/syntra_progress_bar.dart';
 import 'package:timezone/data/latest.dart' as tz;
 
+const int _kAbortLockSeconds = 15;
+const double _kFullReward = 1.0;
+const double _kLateReward = 0.8;
+const double _kAbortPenalty = -0.5;
+
 class ActiveChallengeScreen extends ConsumerStatefulWidget {
   final Challenge challenge;
   final bool isDailyMission;
@@ -39,7 +44,7 @@ class ActiveChallengeScreen extends ConsumerStatefulWidget {
 
 class _ActiveChallengeScreenState extends ConsumerState<ActiveChallengeScreen>
     with TickerProviderStateMixin, WidgetsBindingObserver {
-  int abortLockTimer = 15;
+  int abortLockTimer = _kAbortLockSeconds;
   int mainTimer = 0;
 
   late DateTime _startTime;
@@ -288,8 +293,8 @@ class _ActiveChallengeScreenState extends ConsumerState<ActiveChallengeScreen>
                       // ── Primary action ─────────────────────────────────
                       if (over)
                         SyntraButton.icon(
-                          onPressed: () =>
-                              _onDonePressed(mainTimeOver ? 0.8 : 1.0),
+                          onPressed: () => _onDonePressed(
+                              mainTimeOver ? _kLateReward : _kFullReward),
                           height: mainTimeOver ? buttonH + 8 : buttonH,
                           icon:
                               mainTimeOver ? Icons.flash_on : Icons.check,
@@ -365,7 +370,7 @@ class _ActiveChallengeScreenState extends ConsumerState<ActiveChallengeScreen>
     }
     SoundService.playError(enabled: ref.read(soundEffectsEnabledProvider));
     await Future.delayed(const Duration(milliseconds: 600));
-    await _finishChallenge(-0.5);
+    await _finishChallenge(_kAbortPenalty);
   }
 }
 

--- a/lib/routes/challenges/challenge_list_item.dart
+++ b/lib/routes/challenges/challenge_list_item.dart
@@ -4,8 +4,8 @@ import 'package:syntra/challenge.dart';
 import '../../generated/l10n.dart';
 import '../../logic/comfort_zone_logic.dart';
 import '../../routes/challenge_detail_screen.dart';
-// TODO: re-enable when backend is available: import '../../routes/challenge_done_screen.dart' show socialProofCount;
 import '../../theme/app_spacing.dart';
+import '../../theme/app_theme.dart';
 import '../../widgets/syntra_button.dart';
 
 class ChallengeListItem extends StatelessWidget {
@@ -26,7 +26,7 @@ class ChallengeListItem extends StatelessWidget {
     final cardColor = isDone
         ? Color.lerp(
             Theme.of(context).cardTheme.color ?? cs.surfaceContainer,
-            const Color(0xFF10B981),
+            AppTheme.successGreen,
             0.12,
           )
         : null;
@@ -79,10 +79,10 @@ class ChallengeListItem extends StatelessWidget {
                         ),
                       ),
                       if (isDone)
-                        Padding(
-                          padding: const EdgeInsets.only(left: AppSpacing.xs),
-                          child: const Icon(Icons.check_circle_rounded,
-                              size: 16, color: Color(0xFF10B981)),
+                        const Padding(
+                          padding: EdgeInsets.only(left: AppSpacing.xs),
+                          child: Icon(Icons.check_circle_rounded,
+                              size: 16, color: AppTheme.successGreen),
                         ),
                       if (challenge.flirt)
                         Padding(
@@ -102,14 +102,6 @@ class ChallengeListItem extends StatelessWidget {
                         .bodyMedium
                         ?.copyWith(color: cs.onSurfaceVariant),
                   ),
-                  // TODO: re-enable social proof once backend provides real participant counts
-                  // const SizedBox(height: AppSpacing.xs),
-                  // Text(
-                  //   '~${socialProofCount(challenge.id)} people in this community have tried this',
-                  //   style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  //         color: cs.onSurfaceVariant.withAlpha(160),
-                  //       ),
-                  // ),
                 ],
               ),
             ),

--- a/lib/routes/daily_challenge_screen.dart
+++ b/lib/routes/daily_challenge_screen.dart
@@ -3,44 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../generated/l10n.dart';
 import '../logic/daily_missions_logic.dart';
+import '../providers/daily_providers.dart';
 import '../providers/scroll_providers.dart';
-import '../providers/settings_providers.dart';
-import '../providers/shared_preferences_provider.dart';
 import '../providers/statistics_providers.dart';
 import '../router.dart';
 import '../theme/app_spacing.dart';
+import '../theme/app_theme.dart';
 import '../widgets/syntra_blur_app_bar.dart';
 import '../widgets/syntra_button.dart';
 import '../widgets/syntra_progress_bar.dart';
 import 'challenge_detail_screen.dart';
 import 'challenges/challenge_list_item.dart' show MetaChip;
-
-// ─── Provider ─────────────────────────────────────────────────────────────────
-
-final dailyMissionsProvider =
-    AsyncNotifierProvider<DailyMissionsNotifier, List<DailyMission>>(
-        DailyMissionsNotifier.new);
-
-class DailyMissionsNotifier extends AsyncNotifier<List<DailyMission>> {
-  @override
-  Future<List<DailyMission>> build() async {
-    final lang = ref.watch(activeLocaleProvider);
-    final prefs = ref.read(sharedPreferencesProvider);
-    return DailyMissionsLogic().getTodayMissions(lang, prefs);
-  }
-
-  Future<void> markCompleted(MissionTier tier) async {
-    final prefs = ref.read(sharedPreferencesProvider);
-    await DailyMissionsLogic().markCompleted(tier, prefs);
-    final current = state.value;
-    if (current == null) return;
-    state = AsyncData(
-      current
-          .map((m) => m.tier == tier ? m.copyWith(completed: true) : m)
-          .toList(),
-    );
-  }
-}
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
@@ -228,7 +201,7 @@ class _MissionCard extends StatelessWidget {
     final cardColor = done
         ? Color.lerp(
             Theme.of(context).cardTheme.color ?? cs.surfaceContainer,
-            const Color(0xFF10B981),
+            AppTheme.successGreen,
             0.12,
           )
         : null;
@@ -369,7 +342,7 @@ class _TierHeader extends StatelessWidget {
           const Padding(
             padding: EdgeInsets.only(left: AppSpacing.xs),
             child: Icon(Icons.check_circle_rounded,
-                size: 16, color: Color(0xFF10B981)),
+                size: 16, color: AppTheme.successGreen),
           ),
         if (flirt)
           Padding(

--- a/lib/routes/logbook/field_rows.dart
+++ b/lib/routes/logbook/field_rows.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import '../../generated/l10n.dart';
+import '../../theme/app_spacing.dart';
+
+// ─── Emotion helpers (package-visible so other logbook widgets can import) ────
+
+IconData emotionIcon(int? feeling) {
+  switch (feeling) {
+    case 0: return Icons.sentiment_very_dissatisfied;
+    case 1: return Icons.sentiment_dissatisfied;
+    case 2: return Icons.sentiment_neutral;
+    case 3: return Icons.sentiment_satisfied;
+    case 4: return Icons.sentiment_very_satisfied;
+    default: return Icons.sentiment_neutral;
+  }
+}
+
+Color emotionColor(int? feeling) {
+  switch (feeling) {
+    case 0: return Colors.red;
+    case 1: return Colors.orange;
+    case 2: return Colors.amber;
+    case 3: return Colors.lightGreen;
+    case 4: return Colors.green;
+    default: return Colors.grey;
+  }
+}
+
+String emotionText(BuildContext context, int? feeling) {
+  final l = S.of(context);
+  switch (feeling) {
+    case 0: return l.veryBad;
+    case 1: return l.bad;
+    case 2: return l.neutral;
+    case 3: return l.good;
+    case 4: return l.veryGood;
+    default: return l.unknown;
+  }
+}
+
+// ─── Feelings row ─────────────────────────────────────────────────────────────
+
+class LogbookFeelingsRow extends StatelessWidget {
+  final int? feeling;
+  final int? perception;
+
+  const LogbookFeelingsRow({
+    super.key,
+    required this.feeling,
+    required this.perception,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: _FeelCard(label: l.howDidYouFeelQuestion, value: feeling),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: _FeelCard(label: l.howPerceivedByOthers, value: perception),
+        ),
+      ],
+    );
+  }
+}
+
+class _FeelCard extends StatelessWidget {
+  final String label;
+  final int? value;
+
+  const _FeelCard({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final color = emotionColor(value);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          children: [
+            Text(
+              label,
+              style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(emotionIcon(value), color: color, size: 26),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              emotionText(context, value),
+              style: tt.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/logbook/mood_display.dart
+++ b/lib/routes/logbook/mood_display.dart
@@ -1,0 +1,98 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../generated/l10n.dart';
+import '../../providers/statistics_providers.dart' show moodHistoryProvider;
+import '../../theme/app_spacing.dart';
+
+class LogbookMoodChartCard extends ConsumerWidget {
+  final String challengeId;
+
+  const LogbookMoodChartCard({super.key, required this.challengeId});
+
+  static const _smileyLabels = ['😞', '😕', '😐', '😊', '😄'];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(moodHistoryProvider(challengeId));
+    return async.when(
+      loading: () => const SizedBox.shrink(),
+      error: (e, _) => const SizedBox.shrink(),
+      data: (scores) {
+        if (scores.length < 2) return const SizedBox.shrink();
+        final cs = Theme.of(context).colorScheme;
+        final tt = Theme.of(context).textTheme;
+        final spots = [
+          for (var i = 0; i < scores.length; i++)
+            FlSpot(i.toDouble(), scores[i].toDouble()),
+        ];
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.show_chart_rounded, size: 18, color: cs.primary),
+                    const SizedBox(width: AppSpacing.xs),
+                    Text(
+                      S.of(context).moodTrend,
+                      style: tt.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold, color: cs.primary),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.md),
+                SizedBox(
+                  height: 100,
+                  child: LineChart(
+                    LineChartData(
+                      minY: 0,
+                      maxY: 4,
+                      gridData: const FlGridData(show: false),
+                      borderData: FlBorderData(show: false),
+                      titlesData: FlTitlesData(
+                        leftTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            reservedSize: 28,
+                            interval: 2,
+                            getTitlesWidget: (v, _) => Text(
+                              _smileyLabels[v.round().clamp(0, 4)],
+                              style: const TextStyle(fontSize: 12),
+                            ),
+                          ),
+                        ),
+                        bottomTitles: const AxisTitles(
+                            sideTitles: SideTitles(showTitles: false)),
+                        topTitles: const AxisTitles(
+                            sideTitles: SideTitles(showTitles: false)),
+                        rightTitles: const AxisTitles(
+                            sideTitles: SideTitles(showTitles: false)),
+                      ),
+                      lineBarsData: [
+                        LineChartBarData(
+                          spots: spots,
+                          isCurved: true,
+                          color: cs.primary,
+                          barWidth: 2.5,
+                          dotData: FlDotData(show: spots.length <= 10),
+                          belowBarData: BarAreaData(
+                            show: true,
+                            color: cs.primary.withValues(alpha: 0.12),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/routes/logbook/notes_section.dart
+++ b/lib/routes/logbook/notes_section.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../generated/l10n.dart';
+import '../../theme/app_spacing.dart';
+
+class LogbookNotesCard extends StatelessWidget {
+  final String notes;
+
+  const LogbookNotesCard({super.key, required this.notes});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.notes_rounded, size: 18, color: cs.primary),
+                const SizedBox(width: AppSpacing.xs),
+                Text(
+                  S.of(context).notes,
+                  style: tt.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold, color: cs.primary),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerHigh,
+                borderRadius: BorderRadius.circular(12),
+                border: Border(
+                  left: BorderSide(color: cs.primary, width: 3),
+                ),
+              ),
+              child: Text(
+                notes,
+                style: tt.bodyMedium?.copyWith(height: 1.6),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/logbook_detail_page.dart
+++ b/lib/routes/logbook_detail_page.dart
@@ -1,12 +1,15 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/logbook_repository.dart';
 import '../generated/l10n.dart';
-import '../providers/statistics_providers.dart' show moodHistoryProvider, refreshStatistics;
+import '../providers/statistics_providers.dart' show refreshStatistics;
 import '../theme/app_spacing.dart';
+import '../theme/app_theme.dart';
 import '../widgets/syntra_button.dart';
+import 'logbook/field_rows.dart';
+import 'logbook/mood_display.dart';
+import 'logbook/notes_section.dart';
 
 class LogbookDetailPage extends ConsumerStatefulWidget {
   final Map<String, dynamic> entry;
@@ -64,65 +67,7 @@ class _LogbookDetailPageState extends ConsumerState<LogbookDetailPage>
 
   Color _statusColor(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return _isSuccess ? const Color(0xFF10B981) : cs.tertiary;
-  }
-
-  String _formatDate(String? timestamp) {
-    if (timestamp == null || timestamp.isEmpty) return S.of(context).unknown;
-    try {
-      final dt = DateTime.parse(timestamp);
-      return '${dt.day.toString().padLeft(2, '0')}.'
-          '${dt.month.toString().padLeft(2, '0')}.'
-          '${dt.year}';
-    } catch (_) {
-      return timestamp;
-    }
-  }
-
-  String _localizedStatus(String? status) {
-    final l = S.of(context);
-    switch (status) {
-      case 'success':
-        return l.statusSuccess;
-      case 'tried':
-        return l.statusTried;
-      default:
-        return status ?? l.unknown;
-    }
-  }
-
-  IconData _emotionIcon(int? feeling) {
-    switch (feeling) {
-      case 0: return Icons.sentiment_very_dissatisfied;
-      case 1: return Icons.sentiment_dissatisfied;
-      case 2: return Icons.sentiment_neutral;
-      case 3: return Icons.sentiment_satisfied;
-      case 4: return Icons.sentiment_very_satisfied;
-      default: return Icons.sentiment_neutral;
-    }
-  }
-
-  Color _emotionColor(int? feeling) {
-    switch (feeling) {
-      case 0: return Colors.red;
-      case 1: return Colors.orange;
-      case 2: return Colors.amber;
-      case 3: return Colors.lightGreen;
-      case 4: return Colors.green;
-      default: return Colors.grey;
-    }
-  }
-
-  String _emotionText(int? feeling) {
-    final l = S.of(context);
-    switch (feeling) {
-      case 0: return l.veryBad;
-      case 1: return l.bad;
-      case 2: return l.neutral;
-      case 3: return l.good;
-      case 4: return l.veryGood;
-      default: return l.unknown;
-    }
+    return _isSuccess ? AppTheme.successGreen : cs.tertiary;
   }
 
   // ─── Actions ───────────────────────────────────────────────────────────────
@@ -190,15 +135,13 @@ class _LogbookDetailPageState extends ConsumerState<LogbookDetailPage>
                     onPressed: _deleteEntry,
                     color: cs.error,
                     height: 52,
-                    child: Text(l.delete,
-                        style: TextStyle(color: cs.onError)),
+                    child: Text(l.delete, style: TextStyle(color: cs.onError)),
                   ),
                 ),
                 TextButton(
                   onPressed: () => Navigator.of(ctx).pop(),
                   child: Text(l.cancel,
-                      style:
-                          TextStyle(color: cs.onSurfaceVariant, fontSize: 13)),
+                      style: TextStyle(color: cs.onSurfaceVariant, fontSize: 13)),
                 ),
                 const SizedBox(height: AppSpacing.md),
               ],
@@ -292,23 +235,15 @@ class _LogbookDetailPageState extends ConsumerState<LogbookDetailPage>
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
                         _HeroCard(
+                          entry: widget.entry,
                           title: widget.title,
-                          earned: widget.entry['earned'] ?? 0,
-                          status: widget.entry['status']?.toString(),
-                          timestamp: widget.entry['timestamp']?.toString(),
-                          rewardFactor: widget.entry['reward_factor'],
                           statusColor: _statusColor(context),
                           isSuccess: _isSuccess,
-                          formatDate: _formatDate,
-                          localizedStatus: _localizedStatus,
                         ),
                         const SizedBox(height: AppSpacing.md),
-                        _FeelingsRow(
+                        LogbookFeelingsRow(
                           feeling: widget.entry['feeling'] as int?,
                           perception: widget.entry['perception'] as int?,
-                          emotionIcon: _emotionIcon,
-                          emotionColor: _emotionColor,
-                          emotionText: _emotionText,
                         ),
                         if (widget.entry['pre_anxiety'] != null &&
                             widget.entry['feeling'] != null) ...[
@@ -316,18 +251,17 @@ class _LogbookDetailPageState extends ConsumerState<LogbookDetailPage>
                           _PredictionRealityGapCard(
                             preAnxiety: widget.entry['pre_anxiety'] as int,
                             feeling: widget.entry['feeling'] as int,
-                            emotionIcon: _emotionIcon,
-                            emotionColor: _emotionColor,
-                            emotionText: _emotionText,
                           ),
                         ],
                         if (widget.entry['notes'] != null &&
                             widget.entry['notes'].toString().isNotEmpty) ...[
                           const SizedBox(height: AppSpacing.md),
-                          _NotesCard(notes: widget.entry['notes'].toString()),
+                          LogbookNotesCard(
+                            notes: widget.entry['notes'].toString(),
+                          ),
                         ],
                         const SizedBox(height: AppSpacing.md),
-                        _MoodCard(
+                        LogbookMoodChartCard(
                           challengeId:
                               widget.entry['challenge_id']?.toString() ?? '',
                         ),
@@ -364,43 +298,56 @@ class _LogbookDetailPageState extends ConsumerState<LogbookDetailPage>
 // ─── Hero card ────────────────────────────────────────────────────────────────
 
 class _HeroCard extends StatelessWidget {
+  final Map<String, dynamic> entry;
   final String title;
-  final int earned;
-  final String? status;
-  final String? timestamp;
-  final dynamic rewardFactor;
   final Color statusColor;
   final bool isSuccess;
-  final String Function(String?) formatDate;
-  final String Function(String?) localizedStatus;
 
   const _HeroCard({
+    required this.entry,
     required this.title,
-    required this.earned,
-    required this.status,
-    required this.timestamp,
-    required this.rewardFactor,
     required this.statusColor,
     required this.isSuccess,
-    required this.formatDate,
-    required this.localizedStatus,
   });
+
+  String _formatDate(BuildContext context, String? timestamp) {
+    if (timestamp == null || timestamp.isEmpty) return S.of(context).unknown;
+    try {
+      final dt = DateTime.parse(timestamp);
+      return '${dt.day.toString().padLeft(2, '0')}.'
+          '${dt.month.toString().padLeft(2, '0')}.'
+          '${dt.year}';
+    } catch (_) {
+      return timestamp;
+    }
+  }
+
+  String _localizedStatus(BuildContext context, String? status) {
+    final l = S.of(context);
+    switch (status) {
+      case 'success':
+        return l.statusSuccess;
+      case 'tried':
+        return l.statusTried;
+      default:
+        return status ?? l.unknown;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
     final l = S.of(context);
+    final earned = entry['earned'] ?? 0;
+    final rewardFactor = entry['reward_factor'];
 
     return Card(
       clipBehavior: Clip.hardEdge,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Container(
-            height: 4,
-            color: statusColor,
-          ),
+          Container(height: 4, color: statusColor),
           Padding(
             padding: const EdgeInsets.fromLTRB(
                 AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, AppSpacing.md),
@@ -435,9 +382,8 @@ class _HeroCard extends StatelessWidget {
                         size: 14, color: cs.onSurfaceVariant),
                     const SizedBox(width: 4),
                     Text(
-                      formatDate(timestamp),
-                      style:
-                          tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                      _formatDate(context, entry['timestamp']?.toString()),
+                      style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
                     ),
                     const SizedBox(width: AppSpacing.sm),
                     Container(
@@ -448,7 +394,7 @@ class _HeroCard extends StatelessWidget {
                         borderRadius: BorderRadius.circular(20),
                       ),
                       child: Text(
-                        localizedStatus(status),
+                        _localizedStatus(context, entry['status']?.toString()),
                         style: tt.labelSmall?.copyWith(
                           color: statusColor,
                           fontWeight: FontWeight.bold,
@@ -470,7 +416,7 @@ class _HeroCard extends StatelessWidget {
                 Icon(Icons.star_rounded, color: statusColor, size: 18),
                 const SizedBox(width: 4),
                 Text(
-                  '${earned >= 0 ? '+' : ''}$earned ${S.of(context).auraPoints}',
+                  '${earned >= 0 ? '+' : ''}$earned ${l.auraPoints}',
                   style: tt.titleMedium?.copyWith(
                     color: statusColor,
                     fontWeight: FontWeight.bold,
@@ -478,11 +424,7 @@ class _HeroCard extends StatelessWidget {
                 ),
                 if (rewardFactor != null) ...[
                   const SizedBox(width: AppSpacing.md),
-                  Container(
-                    width: 1,
-                    height: 16,
-                    color: cs.outlineVariant,
-                  ),
+                  Container(width: 1, height: 16, color: cs.outlineVariant),
                   const SizedBox(width: AppSpacing.md),
                   Icon(Icons.trending_up_rounded,
                       size: 16, color: cs.onSurfaceVariant),
@@ -509,176 +451,15 @@ class _HeroCard extends StatelessWidget {
   }
 }
 
-// ─── Feelings row ─────────────────────────────────────────────────────────────
-
-class _FeelingsRow extends StatelessWidget {
-  final int? feeling;
-  final int? perception;
-  final IconData Function(int?) emotionIcon;
-  final Color Function(int?) emotionColor;
-  final String Function(int?) emotionText;
-
-  const _FeelingsRow({
-    required this.feeling,
-    required this.perception,
-    required this.emotionIcon,
-    required this.emotionColor,
-    required this.emotionText,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l = S.of(context);
-    return Row(
-      children: [
-        Expanded(
-          child: _FeelCard(
-            label: l.howDidYouFeelQuestion,
-            value: feeling,
-            emotionIcon: emotionIcon,
-            emotionColor: emotionColor,
-            emotionText: emotionText,
-          ),
-        ),
-        const SizedBox(width: AppSpacing.sm),
-        Expanded(
-          child: _FeelCard(
-            label: l.howPerceivedByOthers,
-            value: perception,
-            emotionIcon: emotionIcon,
-            emotionColor: emotionColor,
-            emotionText: emotionText,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _FeelCard extends StatelessWidget {
-  final String label;
-  final int? value;
-  final IconData Function(int?) emotionIcon;
-  final Color Function(int?) emotionColor;
-  final String Function(int?) emotionText;
-
-  const _FeelCard({
-    required this.label,
-    required this.value,
-    required this.emotionIcon,
-    required this.emotionColor,
-    required this.emotionText,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    final color = emotionColor(value);
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: Column(
-          children: [
-            Text(
-              label,
-              style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Container(
-              width: 48,
-              height: 48,
-              decoration: BoxDecoration(
-                color: color.withValues(alpha: 0.12),
-                shape: BoxShape.circle,
-              ),
-              child: Icon(emotionIcon(value), color: color, size: 26),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Text(
-              emotionText(value),
-              style: tt.bodyMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: color,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ─── Notes card ───────────────────────────────────────────────────────────────
-
-class _NotesCard extends StatelessWidget {
-  final String notes;
-  const _NotesCard({required this.notes});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(Icons.notes_rounded, size: 18, color: cs.primary),
-                const SizedBox(width: AppSpacing.xs),
-                Text(
-                  S.of(context).notes,
-                  style: tt.titleSmall?.copyWith(
-                      fontWeight: FontWeight.bold, color: cs.primary),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(AppSpacing.md),
-              decoration: BoxDecoration(
-                color: cs.surfaceContainerHigh,
-                borderRadius: BorderRadius.circular(12),
-                border: Border(
-                  left: BorderSide(color: cs.primary, width: 3),
-                ),
-              ),
-              child: Text(
-                notes,
-                style: tt.bodyMedium?.copyWith(height: 1.6),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 // ─── Prediction-reality gap card ──────────────────────────────────────────────
 
 class _PredictionRealityGapCard extends StatelessWidget {
   final int preAnxiety;
   final int feeling;
-  final IconData Function(int?) emotionIcon;
-  final Color Function(int?) emotionColor;
-  final String Function(int?) emotionText;
 
   const _PredictionRealityGapCard({
     required this.preAnxiety,
     required this.feeling,
-    required this.emotionIcon,
-    required this.emotionColor,
-    required this.emotionText,
   });
 
   int get _anxietyAsFeelingScale => (5 - preAnxiety).clamp(0, 4);
@@ -726,8 +507,8 @@ class _PredictionRealityGapCard extends StatelessWidget {
                 Column(
                   children: [
                     Text(l.beforeLabel,
-                        style: tt.labelSmall
-                            ?.copyWith(color: cs.onSurfaceVariant)),
+                        style:
+                            tt.labelSmall?.copyWith(color: cs.onSurfaceVariant)),
                     const SizedBox(height: AppSpacing.xs),
                     Container(
                       width: 48,
@@ -740,10 +521,9 @@ class _PredictionRealityGapCard extends StatelessWidget {
                           color: beforeColor, size: 26),
                     ),
                     const SizedBox(height: AppSpacing.xs),
-                    Text(emotionText(_anxietyAsFeelingScale),
+                    Text(emotionText(context, _anxietyAsFeelingScale),
                         style: tt.labelSmall?.copyWith(
-                            color: beforeColor,
-                            fontWeight: FontWeight.bold)),
+                            color: beforeColor, fontWeight: FontWeight.bold)),
                   ],
                 ),
                 Icon(Icons.arrow_forward_rounded,
@@ -751,8 +531,8 @@ class _PredictionRealityGapCard extends StatelessWidget {
                 Column(
                   children: [
                     Text(l.afterLabel,
-                        style: tt.labelSmall
-                            ?.copyWith(color: cs.onSurfaceVariant)),
+                        style:
+                            tt.labelSmall?.copyWith(color: cs.onSurfaceVariant)),
                     const SizedBox(height: AppSpacing.xs),
                     Container(
                       width: 48,
@@ -765,10 +545,9 @@ class _PredictionRealityGapCard extends StatelessWidget {
                           color: afterColor, size: 26),
                     ),
                     const SizedBox(height: AppSpacing.xs),
-                    Text(emotionText(feeling),
+                    Text(emotionText(context, feeling),
                         style: tt.labelSmall?.copyWith(
-                            color: afterColor,
-                            fontWeight: FontWeight.bold)),
+                            color: afterColor, fontWeight: FontWeight.bold)),
                   ],
                 ),
               ],
@@ -792,99 +571,6 @@ class _PredictionRealityGapCard extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-// ─── Mood trend card ──────────────────────────────────────────────────────────
-
-class _MoodCard extends ConsumerWidget {
-  final String challengeId;
-  const _MoodCard({required this.challengeId});
-
-  static const _smileyLabels = ['😞', '😕', '😐', '😊', '😄'];
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final async = ref.watch(moodHistoryProvider(challengeId));
-    return async.when(
-      loading: () => const SizedBox.shrink(),
-      error: (e, st) => const SizedBox.shrink(),
-      data: (scores) {
-        if (scores.length < 2) return const SizedBox.shrink();
-        final cs = Theme.of(context).colorScheme;
-        final tt = Theme.of(context).textTheme;
-        final spots = [
-          for (var i = 0; i < scores.length; i++)
-            FlSpot(i.toDouble(), scores[i].toDouble()),
-        ];
-        return Card(
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.md),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(Icons.show_chart_rounded,
-                        size: 18, color: cs.primary),
-                    const SizedBox(width: AppSpacing.xs),
-                    Text(
-                      S.of(context).moodTrend,
-                      style: tt.titleSmall?.copyWith(
-                          fontWeight: FontWeight.bold, color: cs.primary),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: AppSpacing.md),
-                SizedBox(
-                  height: 100,
-                  child: LineChart(
-                    LineChartData(
-                      minY: 0,
-                      maxY: 4,
-                      gridData: const FlGridData(show: false),
-                      borderData: FlBorderData(show: false),
-                      titlesData: FlTitlesData(
-                        leftTitles: AxisTitles(
-                          sideTitles: SideTitles(
-                            showTitles: true,
-                            reservedSize: 28,
-                            interval: 2,
-                            getTitlesWidget: (v, _) => Text(
-                              _smileyLabels[v.round().clamp(0, 4)],
-                              style: const TextStyle(fontSize: 12),
-                            ),
-                          ),
-                        ),
-                        bottomTitles: const AxisTitles(
-                            sideTitles: SideTitles(showTitles: false)),
-                        topTitles: const AxisTitles(
-                            sideTitles: SideTitles(showTitles: false)),
-                        rightTitles: const AxisTitles(
-                            sideTitles: SideTitles(showTitles: false)),
-                      ),
-                      lineBarsData: [
-                        LineChartBarData(
-                          spots: spots,
-                          isCurved: true,
-                          color: cs.primary,
-                          barWidth: 2.5,
-                          dotData: FlDotData(show: spots.length <= 10),
-                          belowBarData: BarAreaData(
-                            show: true,
-                            color: cs.primary.withValues(alpha: 0.12),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
     );
   }
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -8,6 +8,9 @@ abstract class AppTheme {
   /// Primary brand color — Neon Pink.
   static const Color seedColor = Color(0xFFFF10F0);
 
+  /// Colour used for "done / success" states (checkmark icons, completed-card tint).
+  static const Color successGreen = Color(0xFF10B981);
+
   static ThemeData light() {
     return ThemeData(
       useMaterial3: true,

--- a/test/badges_logic_test.dart
+++ b/test/badges_logic_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:syntra/logic/badges_logic.dart';
+
+Map<String, int> _stats({
+  int completedAllTime = 0,
+  int totalXp = 0,
+  int minutesBrave = 0,
+  int czlLevel = 1,
+}) => {
+      'completedAllTime': completedAllTime,
+      'totalXp': totalXp,
+      'minutesBrave': minutesBrave,
+      'czlLevel': czlLevel,
+    };
+
+bool _earned(String id, Map<String, int> stats, {int bestStreak = 0}) {
+  final badge = BadgesLogic.all.firstWhere((b) => b.id == id);
+  return badge.isEarned(stats, bestStreak);
+}
+
+void main() {
+  group('BadgesLogic — first_step', () {
+    test('not earned with 0 completions', () {
+      expect(_earned('first_step', _stats()), isFalse);
+    });
+    test('earned at exactly 1 completion', () {
+      expect(_earned('first_step', _stats(completedAllTime: 1)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — ten_challenges', () {
+    test('not earned with 9 completions', () {
+      expect(_earned('ten_challenges', _stats(completedAllTime: 9)), isFalse);
+    });
+    test('earned at exactly 10 completions', () {
+      expect(_earned('ten_challenges', _stats(completedAllTime: 10)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — fifty_challenges', () {
+    test('not earned with 49 completions', () {
+      expect(_earned('fifty_challenges', _stats(completedAllTime: 49)), isFalse);
+    });
+    test('earned at exactly 50 completions', () {
+      expect(_earned('fifty_challenges', _stats(completedAllTime: 50)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — three_week_streak', () {
+    test('not earned with best streak of 2', () {
+      expect(_earned('three_week_streak', _stats(), bestStreak: 2), isFalse);
+    });
+    test('earned at exactly 3 weeks', () {
+      expect(_earned('three_week_streak', _stats(), bestStreak: 3), isTrue);
+    });
+  });
+
+  group('BadgesLogic — seven_week_streak', () {
+    test('not earned with best streak of 6', () {
+      expect(_earned('seven_week_streak', _stats(), bestStreak: 6), isFalse);
+    });
+    test('earned at exactly 7 weeks', () {
+      expect(_earned('seven_week_streak', _stats(), bestStreak: 7), isTrue);
+    });
+  });
+
+  group('BadgesLogic — century_xp', () {
+    test('not earned with 99 XP', () {
+      expect(_earned('century_xp', _stats(totalXp: 99)), isFalse);
+    });
+    test('earned at exactly 100 XP', () {
+      expect(_earned('century_xp', _stats(totalXp: 100)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — five_hundred_xp', () {
+    test('not earned with 499 XP', () {
+      expect(_earned('five_hundred_xp', _stats(totalXp: 499)), isFalse);
+    });
+    test('earned at exactly 500 XP', () {
+      expect(_earned('five_hundred_xp', _stats(totalXp: 500)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — brave_minutes', () {
+    test('not earned with 59 minutes', () {
+      expect(_earned('brave_minutes', _stats(minutesBrave: 59)), isFalse);
+    });
+    test('earned at exactly 60 minutes', () {
+      expect(_earned('brave_minutes', _stats(minutesBrave: 60)), isTrue);
+    });
+  });
+
+  group('BadgesLogic — level badges', () {
+    for (int lvl = 2; lvl <= 10; lvl++) {
+      final id = 'level_$lvl';
+      test('$id not earned at CZL ${lvl - 1}', () {
+        expect(_earned(id, _stats(czlLevel: lvl - 1)), isFalse);
+      });
+      test('$id earned at CZL $lvl', () {
+        expect(_earned(id, _stats(czlLevel: lvl)), isTrue);
+      });
+    }
+  });
+
+  group('BadgesLogic.computeEarned', () {
+    test('returns empty set for a brand-new user', () {
+      expect(BadgesLogic.computeEarned(_stats(), 0), isEmpty);
+    });
+
+    test('returns all non-level badges for a highly experienced user', () {
+      final earned = BadgesLogic.computeEarned(
+        _stats(
+          completedAllTime: 100,
+          totalXp: 1000,
+          minutesBrave: 120,
+          czlLevel: 10,
+        ),
+        10,
+      );
+      expect(earned, containsAll([
+        'first_step',
+        'ten_challenges',
+        'fifty_challenges',
+        'three_week_streak',
+        'seven_week_streak',
+        'century_xp',
+        'five_hundred_xp',
+        'brave_minutes',
+      ]));
+    });
+  });
+}

--- a/test/displayed_challenges_test.dart
+++ b/test/displayed_challenges_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:syntra/challenge.dart';
+import 'package:syntra/providers/challenge_providers.dart';
+import 'package:syntra/providers/shared_preferences_provider.dart';
+import 'package:syntra/providers/statistics_providers.dart';
+
+Challenge _c(String id, {int xp = 50}) => Challenge(
+      id: id,
+      title: 'T',
+      description: 'D',
+      xp: xp,
+    );
+
+/// Creates a container where [challengeFiltersProvider] starts with [prefs] values.
+Future<ProviderContainer> _container({
+  required List<Challenge> catalog,
+  Map<String, Object> filterPrefs = const {},
+  Set<String> completedIds = const {},
+  Map<String, DateTime> completionDates = const {},
+}) async {
+  SharedPreferences.setMockInitialValues(filterPrefs);
+  final prefs = await SharedPreferences.getInstance();
+
+  final c = ProviderContainer(overrides: [
+    filteredChallengesProvider.overrideWithValue(AsyncData(catalog)),
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    completedChallengeIdsProvider.overrideWith((_) async => completedIds),
+    latestCompletionDatesProvider.overrideWith((_) async => completionDates),
+  ]);
+  // Pump the FutureProviders so their values are available synchronously.
+  await c.read(completedChallengeIdsProvider.future);
+  await c.read(latestCompletionDatesProvider.future);
+  return c;
+}
+
+/// Key used by [ChallengeFiltersNotifier] for the completion filter pref.
+const _kCompletionKey = 'filter_completion';
+const _kAuraSortKey = 'filter_aura_sort';
+const _kCompletionSortKey = 'filter_completion_sort';
+
+void main() {
+  group('displayedChallengesProvider — completion filter', () {
+    final catalog = [_c('1'), _c('2'), _c('3')];
+
+    test('CompletionFilter.all returns all challenges', () async {
+      final c = await _container(catalog: catalog, completedIds: {'1'});
+      addTearDown(c.dispose);
+      expect(c.read(displayedChallengesProvider).valueOrNull?.length, 3);
+    });
+
+    test('CompletionFilter.notDone excludes completed ids', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {_kCompletionKey: CompletionFilter.notDone.index},
+        completedIds: {'1', '3'},
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id);
+      expect(ids?.toList(), ['2']);
+    });
+
+    test('CompletionFilter.done returns only completed ids', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {_kCompletionKey: CompletionFilter.done.index},
+        completedIds: {'2'},
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id);
+      expect(ids?.toList(), ['2']);
+    });
+  });
+
+  group('displayedChallengesProvider — aura sort', () {
+    final catalog = [_c('a', xp: 30), _c('b', xp: 10), _c('c', xp: 20)];
+
+    test('AuraSortOrder.asc sorts ascending by XP', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {_kAuraSortKey: AuraSortOrder.asc.index},
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id);
+      expect(ids?.toList(), ['b', 'c', 'a']);
+    });
+
+    test('AuraSortOrder.desc sorts descending by XP', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {_kAuraSortKey: AuraSortOrder.desc.index},
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id);
+      expect(ids?.toList(), ['a', 'c', 'b']);
+    });
+  });
+
+  group('displayedChallengesProvider — completion date sort', () {
+    final now = DateTime(2026, 1, 10);
+    final catalog = [_c('x'), _c('y'), _c('z')];
+    final dates = {
+      'x': now,
+      'y': now.subtract(const Duration(days: 5)),
+    };
+
+    test('newestFirst puts most recently completed first', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {
+          _kCompletionSortKey: CompletionSortOrder.newestFirst.index,
+        },
+        completionDates: dates,
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id).toList();
+      expect(ids?.first, 'x');
+      expect(ids?.elementAt(1), 'y');
+    });
+
+    test('oldestFirst puts oldest completion first', () async {
+      final c = await _container(
+        catalog: catalog,
+        filterPrefs: {
+          _kCompletionSortKey: CompletionSortOrder.oldestFirst.index,
+        },
+        completionDates: dates,
+      );
+      addTearDown(c.dispose);
+      final ids = c.read(displayedChallengesProvider).valueOrNull?.map((ch) => ch.id).toList();
+      expect(ids?.first, 'y');
+      expect(ids?.elementAt(1), 'x');
+    });
+  });
+}


### PR DESCRIPTION
- Move DailyMissionsNotifier to lib/providers/daily_providers.dart
- Replace hardcoded Color(0xFF10B981) with AppTheme.successGreen constant
- Delete dead social-proof TODO comment block from challenge_list_item.dart
- Extract abort lock / reward factor magic numbers in active_challenge_screen.dart
- Split logbook_detail_page.dart into lib/routes/logbook/ sub-widgets (field_rows.dart, notes_section.dart, mood_display.dart)
- Add badges_logic_test.dart (36 tests, boundary values per badge)
- Add displayed_challenges_test.dart (7 tests for filter/sort logic)